### PR TITLE
bug fix for string key case

### DIFF
--- a/db/skiplist.h
+++ b/db/skiplist.h
@@ -325,7 +325,7 @@ template<typename Key, class Comparator>
 SkipList<Key,Comparator>::SkipList(Comparator cmp, Arena* arena)
     : compare_(cmp),
       arena_(arena),
-      head_(NewNode(0 /* any key will do */, kMaxHeight)),
+      head_(NewNode(Key() /* any key will do */, kMaxHeight)),
       max_height_(reinterpret_cast<void*>(1)),
       rnd_(0xdeadbeef) {
   for (int i = 0; i < kMaxHeight; i++) {


### PR DESCRIPTION
It will coredump, with error 'basic_string::_S_construct null not valid'.

#include <iostream>

#include "skiplist.h"
#include "util/arena.h"

using namespace std;
using namespace leveldb;

struct StringComparator {
  int operator()(const string& a, const string& b) const {
      return a < b;
  }
};

int main()
{
    StringComparator comp;
    Arena arena;

    SkipList<string, StringComparator> tmp(comp, &arena);
    tmp.Insert(string("a"));

    cout << tmp.Contains(string("b")) << endl;
    cout << tmp.Contains(string("a")) << endl;

    cout << "test skiplist" << endl;

    return 0;
}