### PR TITLE
Bugfix for DBImpl::Write when log file error occurs.

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1230,18 +1230,14 @@ Status DBImpl::Write(const WriteOptions& options, WriteBatch* my_batch) {
     {
       mutex_.Unlock();
       status = log_->AddRecord(WriteBatchInternal::Contents(updates));
-      bool sync_error = false;
       if (status.ok() && options.sync) {
         status = logfile_->Sync();
-        if (!status.ok()) {
-          sync_error = true;
-        }
       }
       if (status.ok()) {
         status = WriteBatchInternal::InsertInto(updates, mem_);
       }
       mutex_.Lock();
-      if (sync_error) {
+      if (status.ok()) {
         // The state of the log file is indeterminate: the log record we
         // just added may or may not show up when the DB is re-opened.
         // So we force the DB into a mode where all future writes fail.


### PR DESCRIPTION
Call RecordBackgroundError when the state of the log file is indeterminate, not only when error occurs with write_options.sync=true.

Here is an example show that:
Get() returns **NotFound** even if Put successfully with write_options.sync=true.

The test code is as follow:
```
#include <string>
#include <unistd.h>
#include "leveldb/db.h"

int main() {
    const char* dbname = "./trash/ldb_data";
    leveldb::DB* db = NULL;
    leveldb::Options opts;
    opts.create_if_missing = true;
    leveldb::WriteOptions wopts;
    leveldb::Status s;
    long long count = 0;

    s = leveldb::DB::Open(opts, dbname, &db);
    assert(db != NULL);

    printf("Put until io error(No space left on device) occurs.\n");

    while (true) {
        std::string key = std::to_string(count++);
        s = db->Put(wopts, key, "hello world");
        if (!s.ok()) {
            printf("Put status %s.\n", s.ToString().c_str());
            break;
        }
    }

    printf("Release disk space(not the data in the db).\n");
    sleep(20);

    {
        wopts.sync = true;
        std::string key = std::to_string(count);
        s = db->Put(wopts, key, std::string(32 * 1024, 'x'));
        printf("Put key %s status %s.\n", key.c_str(), s.ToString().c_str());
        assert(s.ok());
    }

    printf("Re-open the leveldb.\n");
    {
        delete db;
        db = NULL;
        s = leveldb::DB::Open(opts, dbname, &db);
        assert(db != NULL);
    }

    printf("Read the key put successfully with wopts.sync=true.\n");
    {
        std::string key = std::to_string(count);
        std::string value;
        s = db->Get(leveldb::ReadOptions(), key, &value);
        printf("Get key %s status %s.\n", key.c_str(), s.ToString().c_str());
        assert(!s.IsNotFound()); // assert happen !!!
    }

    return 0;
}
```

Run the code and the output:

> :~/open/leveldb-master>./a.out
> Put until io error(No space left on device) occurs.
> Put status IO error: ./trash/ldb_data/000715.log: No space left on device.
> Release disk space(not the data in the db).
> Put key 14411510 status OK.
> Re-open the leveldb.
> Read the key put successfully with wopts.sync=true.
> Get key 14411510 status NotFound: .
> a.out: test.cc:53: int main(): Assertion `!s.IsNotFound()' failed.
> Aborted

